### PR TITLE
Fix float32 JSON serialization

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,7 +22,7 @@
 				"ms-python.black-formatter"
 			]
 		}
-	},
+	}
 
 	// Configure tool-specific properties.
 	// "customizations": {},

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,4 +5,4 @@ services:
       dockerfile: Dockerfile
     ports:
       - 8080:8080
-    image: bigdatainbiomedicine/simba-qc:0.2.3
+    image: bigdatainbiomedicine/simba-qc:0.2.4

--- a/src/app.py
+++ b/src/app.py
@@ -4,7 +4,6 @@ import os
 import tempfile
 import anndata as ad
 import json
-import numpy as np
 
 from sliders import slider_ui, slider_server
 from distributions import distributions_server
@@ -12,18 +11,29 @@ from plots import plots_server, plots_ui
 from metadata import metadata_server, metadata_ui
 from helpers import calculate_qc_metrics
 
-
+'''
 def convert_float32_to_float(data):
     if isinstance(data, dict):
         #print('dict')
+        for k, v in data.items():
+            if isinstance(v, np.float32):
+                print(f"Converting 32 {v} to float in dict")
         return {k: convert_float32_to_float(v) for k, v in data.items()}
     elif isinstance(data, list):
-        #print('list')
+        for v in data:
+            if isinstance(v, np.float32):
+                print(f"Converting 32 {v} to float in list")
+    
         return [convert_float32_to_float(v) for v in data]
-    elif isinstance(data, np.float32) or isinstance(data, np.float64):
+    elif isinstance(data, np.float32):
+        if isinstance(data, np.float32):
+            print(f"Converting 32 {data} to float")
         #print(f"Converting {data} to float")
         return float(data)
     elif isinstance(data, np.ndarray):
+        for v in data:
+            if isinstance(v, np.float32):
+                print(f"Converting 32 {v} to float in ndarray")
         #print('ndarray')
         return data.tolist()
     return data
@@ -36,6 +46,8 @@ def custom_json_dumps(data, *args, **kwargs):
     return original_json_dumps(non_float_32_data, *args, **kwargs)
 
 json.dumps = custom_json_dumps
+
+'''
 
 _pretty_names = reactive.value({
     'total_counts': 'Total counts',

--- a/src/app.py
+++ b/src/app.py
@@ -3,9 +3,7 @@ import scanpy as sc
 import os
 import tempfile
 import anndata as ad
-import pandas as pd
 import json
-import logging
 import numpy as np
 
 from sliders import slider_ui, slider_server

--- a/src/app.py
+++ b/src/app.py
@@ -11,43 +11,6 @@ from plots import plots_server, plots_ui
 from metadata import metadata_server, metadata_ui
 from helpers import calculate_qc_metrics
 
-'''
-def convert_float32_to_float(data):
-    if isinstance(data, dict):
-        #print('dict')
-        for k, v in data.items():
-            if isinstance(v, np.float32):
-                print(f"Converting 32 {v} to float in dict")
-        return {k: convert_float32_to_float(v) for k, v in data.items()}
-    elif isinstance(data, list):
-        for v in data:
-            if isinstance(v, np.float32):
-                print(f"Converting 32 {v} to float in list")
-    
-        return [convert_float32_to_float(v) for v in data]
-    elif isinstance(data, np.float32):
-        if isinstance(data, np.float32):
-            print(f"Converting 32 {data} to float")
-        #print(f"Converting {data} to float")
-        return float(data)
-    elif isinstance(data, np.ndarray):
-        for v in data:
-            if isinstance(v, np.float32):
-                print(f"Converting 32 {v} to float in ndarray")
-        #print('ndarray')
-        return data.tolist()
-    return data
-
-# Monkey-patch json.dumps
-original_json_dumps = json.dumps
-
-def custom_json_dumps(data, *args, **kwargs):
-    non_float_32_data = convert_float32_to_float(data)
-    return original_json_dumps(non_float_32_data, *args, **kwargs)
-
-json.dumps = custom_json_dumps
-
-'''
 
 _pretty_names = reactive.value({
     'total_counts': 'Total counts',

--- a/src/plots.py
+++ b/src/plots.py
@@ -140,5 +140,4 @@ def plots_server(
 
         if adata is not None:
             n_cells = int(adata.n_obs)
-            print(type(n_cells))
             return f"{n_cells} cells pass the current filtering thresholds"

--- a/src/plots.py
+++ b/src/plots.py
@@ -45,9 +45,9 @@ def plots_server(
         fig, ax = plt.subplots()
 
         ax.scatter(
-            adata.obs[x_col],
-            adata.obs[y_col],
-            c=adata.obs[color_col],
+            adata.obs[x_col].astype(float),
+            adata.obs[y_col].astype(float),
+            c=adata.obs[color_col].astype(float),
             s=dot_size,
             cmap="viridis",
         )
@@ -133,10 +133,12 @@ def plots_server(
 
         return fig
 
+    @output
     @render.text
     def n_cells():
         adata = _adata.get()
 
         if adata is not None:
-            n_cells = adata.n_obs
+            n_cells = int(adata.n_obs)
+            print(type(n_cells))
             return f"{n_cells} cells pass the current filtering thresholds"

--- a/src/sliders.py
+++ b/src/sliders.py
@@ -39,7 +39,7 @@ def slider_server(
         if adata is None:
             return
 
-        n_obs = adata.n_obs
+        n_obs = int(adata.n_obs)
         return ui.input_slider(
             "random_sample_size",
             "Random sample size",
@@ -120,9 +120,9 @@ def slider_server(
                 absolute = ui.input_slider(
                     f"{col}_absolute",
                     "Absolute value",
-                    distributions[col]["min"],
-                    distributions[col]["max"],
-                    [distributions[col]["min"], distributions[col]["max"]],
+                    float(distributions[col]["min"]),
+                    float(distributions[col]["max"]),
+                    [float(distributions[col]["min"]), float(distributions[col]["max"])],
                 )
                 panel = ui.accordion_panel(pretty_name, mads, absolute)
                 panels.append(panel)

--- a/src/sliders.py
+++ b/src/sliders.py
@@ -155,12 +155,12 @@ def slider_server(
                 if mads is None or absolute is None:
                     continue
 
-                min_val = (
+                min_val = float((
                     distributions[col]["median"] - mads * distributions[col]["std"]
-                )
-                max_val = (
+                ))
+                max_val = float((
                     distributions[col]["median"] + mads * distributions[col]["std"]
-                )
+                ))
 
                 ui.update_slider(absolute_name, value=[min_val, max_val])
 


### PR DESCRIPTION
Fix Error:

```
Traceback (most recent call last):
  File "/home/vscode/.local/lib/python3.10/site-packages/shiny/session/_session.py", line 665, in _run
    await flush()
  File "/home/vscode/.local/lib/python3.10/site-packages/shiny/reactive/_core.py", line 260, in flush
    await _reactive_environment.flush()
  File "/home/vscode/.local/lib/python3.10/site-packages/shiny/reactive/_core.py", line 178, in flush
    await self._flushed_callbacks.invoke()
  File "/home/vscode/.local/lib/python3.10/site-packages/shiny/_utils.py", line 528, in invoke
    await fn()
  File "/home/vscode/.local/lib/python3.10/site-packages/shiny/session/_session.py", line 1021, in _flush
    await self._send_message(message)
  File "/home/vscode/.local/lib/python3.10/site-packages/shiny/session/_session.py", line 960, in _send_message
    message_str: str = json.dumps(message) + "\n"
  File "/usr/local/lib/python3.10/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/usr/local/lib/python3.10/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/local/lib/python3.10/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/usr/local/lib/python3.10/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type float32 is not JSON serializable
**Object of type float32 is not JSON serializable**
```

The issue was resolved by globally converting all possible numerical values into a format that is compatible with JSON. This ensures that both existing and future values are always JSON-serializable, preventing any non-JSON-compatible values from causing errors.